### PR TITLE
#161967088 Implement user reset password feedback

### DIFF
--- a/src/api/resetPasswordAPI.js
+++ b/src/api/resetPasswordAPI.js
@@ -50,9 +50,11 @@ export default class ResetPasswordAPI {
       .catch((response) => {
         if (response.response.status === 504) {
           toastr.info("Please try again after sometime");
+        } else if (response.response.status === 503) {
+          toastr.info("Please try again after sometime");
         } else if (response.response.status === 401) {
           toastr.warning("Reset Link has expired request for another one!");
-        } else if (response.response.data === 500) {
+        } else if (response.response.status === 500) {
           toastr.error("Invalid reset link");
         }
       });

--- a/src/components/containers/__tests__/resetRequest.test.js
+++ b/src/components/containers/__tests__/resetRequest.test.js
@@ -1,12 +1,21 @@
 import React from "react";
 import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureMockStore from "redux-mock-store";
 import ResetRequestPage from "../resetRequest";
+
+const mockStore = configureMockStore();
+const store = mockStore({});
 
 describe("ResetRequest Component", () => {
   let resetComponent = "";
 
   beforeEach(() => {
-    resetComponent = mount(<ResetRequestPage />);
+    resetComponent = mount(
+      <Provider store={store}>
+        <ResetRequestPage />
+      </Provider>
+    );
   });
 
   afterEach(() => {

--- a/src/components/containers/resetRequest.js
+++ b/src/components/containers/resetRequest.js
@@ -1,6 +1,8 @@
 /* eslint-disable no-useless-escape */
 /* eslint-disable react/no-unused-state */
 import React, { Component } from "react";
+import { connect } from "react-redux";
+import PropTypes from "prop-types";
 import ResetView from "../views/ResetRequestForm";
 import ResetPasswordAPI from "../../api/resetPasswordAPI";
 
@@ -40,14 +42,19 @@ class ResetRequestPage extends Component {
   };
 
   render() {
+    const { parent } = this.props;
     return (
       <ResetView
         state={this.state}
         onHandleChange={this.onHandleChange}
         onHandleSubmit={this.onHandleSubmit}
+        parent={parent}
       />
     );
   }
 }
+ResetRequestPage.propTypes = {
+  parent: PropTypes.object.isRequired
+};
 
-export default ResetRequestPage;
+export default connect(null)(ResetRequestPage);

--- a/src/components/containers/updatePassword.js
+++ b/src/components/containers/updatePassword.js
@@ -4,6 +4,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { withRouter } from "react-router-dom";
+import toastr from "../../helpers/toastrConfig";
 import UpdatePasswordView from "../views/UpdatePasswordForm";
 import ResetPasswordAPI from "../../api/resetPasswordAPI";
 
@@ -63,6 +64,7 @@ class UpdatePasswordPage extends Component {
       this.setState({
         passwordButton: true
       });
+      toastr.error("Passwords should MATCH!!");
     }
   };
 

--- a/src/components/views/ResetRequestForm.js
+++ b/src/components/views/ResetRequestForm.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import {
-  Button, Form, Header, Loader, Dimmer, Container
+  Button, Form, Header, Loader, Dimmer, Container, Icon
 } from "semantic-ui-react";
 
 export const HandleErrors = (props) => {
@@ -14,7 +14,9 @@ HandleErrors.propTypes = {
 };
 
 const ResetView = (props) => {
-  const { state, onHandleChange, onHandleSubmit } = props;
+  const {
+    state, onHandleChange, onHandleSubmit, parent
+  } = props;
 
   return (
     <div className="auth__requestReset">
@@ -42,6 +44,20 @@ const ResetView = (props) => {
             </Button>
           </Form.Field>
         </Form>
+        <br />
+        <Button
+          id="backBtn"
+          icon
+          type="button"
+          secondary
+          inverted
+          onClick={() => {
+            parent.setView(2);
+          }}
+        >
+          <Icon name="left arrow" />
+            Back to Login
+        </Button>
       </Container>
 
     </div>
@@ -50,6 +66,7 @@ const ResetView = (props) => {
 
 ResetView.propTypes = {
   state: PropTypes.object.isRequired,
+  parent: PropTypes.object.isRequired,
   onHandleChange: PropTypes.func.isRequired,
   onHandleSubmit: PropTypes.func.isRequired
 };

--- a/src/components/views/UpdatePasswordForm.js
+++ b/src/components/views/UpdatePasswordForm.js
@@ -36,7 +36,7 @@ const UpdatePasswordView = (props) => {
               onChange={onInputChange}
               required
             />
-            {state.confirmPassword.value !== "" && !state.confirmPassword.value ? <HandleErrors message="Password should be alphanumeric and match password above" /> : ""}
+            {state.confirmPassword.value !== "" && !state.confirmPassword.valid ? <HandleErrors message="Password should be alphanumeric and match password above" /> : ""}
           </Form.Field>
           <Button
             className="passwordFrom__sendBtn"

--- a/src/components/views/headers/UserHeader.js
+++ b/src/components/views/headers/UserHeader.js
@@ -1,6 +1,5 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Link } from "react-router-dom";
 import {
   Menu, Container, Input, Image, Header, Responsive, Popup, Divider
 } from "semantic-ui-react";
@@ -39,9 +38,7 @@ export default function UserHeader(props) {
   return (
     <Menu borderless main="true" className="header--user">
       <Container>
-        <Link to="/">
-          <Menu.Item><Header>Authors Haven</Header></Menu.Item>
-        </Link>
+        <Menu.Item><Header>Authors Haven</Header></Menu.Item>
 
         <Menu.Menu position="right" className="secondary">
 


### PR DESCRIPTION
**What does this PR do?**
-  Adds button back to login on user request reset page
- Fix user input validation on confirm password

**Description of tasks to be completed?** 
- Fix bugs on change password page and add button to login

**How should this be manually tested?**
- Clone the repo and cd into the project root folder
- Switch to the relevant branch `git checkout bg-add-link-login-16196708`
- Run `npm install` to update your packages.
- Start the server with `npm start`
- In your favorite browser, navigate to `http://localhost:3000`

**What are the relevant pivotal tracker stories?**
[#161967088(https://www.pivotaltracker.com/story/show/161967088)

#### Screenshots
##### Request reset
![screenshot 2019-01-28 at 20 12 29](https://user-images.githubusercontent.com/16937341/51853409-4c328c80-2339-11e9-983f-9be559d5105e.png)

##### Change password
![screenshot 2019-01-28 at 20 13 12](https://user-images.githubusercontent.com/16937341/51853425-55235e00-2339-11e9-921d-befde58a0781.png)
